### PR TITLE
Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ class Parser extends Transform {
   }
 
   _flush (cb) {
-    const msg = JSON.parse(this._buffer.slice(0, this._buffer.indexOf('}}') + 2))
+    const msg = JSON.parse(this._buffer.slice(0, this._buffer.lastIndexOf('}}') + 2))
     this.push(msg)
     cb(null)
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nearform/trace-events-parser",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Fast streaming parser for Node.js trace events",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nearform/trace-events-parser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fast streaming parser for Node.js trace events",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -1,9 +1,45 @@
 const tape = require('tape')
 const parser = require('./')
 
+tape('basic nested', function (t) {
+  const parse = parser()
+  const expected = [{ a: true, b: {} }, { a: false, b: { c: {} } }]
+  const testData = '{"traceEvents":[{"a":true,"b":{}},{"a":false,"b":{"c":{}}}]}'
+  parse.write(testData)
+  parse.end()
+
+  parse
+    .on('data', function (data) {
+      t.same(data, expected.shift())
+    })
+    .on('end', function () {
+      t.same(expected.length, 0)
+      t.end()
+    })
+})
+
+tape('chunked nested', function (t) {
+  const parse = parser()
+  const expected = [{ a: true, b: {} }, { a: false, b: { c: {} } }]
+  const testData = '{"traceEvents":[{"a":true,"b":{}},{"a":false,"b":{"c":{}}}]}'
+  for (var i = 0; i < testData.length; i++) {
+    parse.write(testData.slice(i, i + 1))
+  }
+  parse.end()
+
+  parse
+    .on('data', function (data) {
+      t.same(data, expected.shift())
+    })
+    .on('end', function () {
+      t.same(expected.length, 0)
+      t.end()
+    })
+})
+
 tape('basic', function (t) {
   const parse = parser()
-  const expected = [{a: true, b: {}}, {a: false, b: {}}]
+  const expected = [{ a: true, b: {} }, { a: false, b: {} }]
 
   parse.write('{"traceEvents":[{"a":true,"b":{}},{"a":false,"b":{}}]}')
   parse.end()
@@ -20,7 +56,7 @@ tape('basic', function (t) {
 
 tape('chunked', function (t) {
   const parse = parser()
-  const expected = [{a: true, b: {}}, {a: false, b: {}}]
+  const expected = [{ a: true, b: {} }, { a: false, b: {} }]
   const s = '{"traceEvents":[{"a":true,"b":{}},{"a":false,"b":{}}]}'
 
   for (var i = 0; i < s.length; i++) {


### PR DESCRIPTION
I was seeing JSON parse failures running bubbleprof. Tracked it down to the args object having a nested ```runtime-call-stats``` property and the call to indexOf finding the first ``}}`` Not sure if there is some other case that this will break, but take a look and see what you think.
```json
{
    "pid": 12345,
    "tid": 123,
    "ts": 123456,
    "tts": 1234,
    "ph": "E",
    "cat": "v8",
    "name": "V8.Execute",
    "dur": 0,
    "tdur": 0,
    "args": {
        "runtime-call-stats": {}
    }
}
```

