### PR TITLE
use turbo-json-parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "devDependencies": {
     "standard": "^11.0.1",
     "tape": "^4.9.1"
+  },
+  "dependencies": {
+    "turbo-json-parse": "^2.2.0"
   }
 }

--- a/parse.js
+++ b/parse.js
@@ -1,0 +1,35 @@
+const turbo = require('turbo-json-parse')
+
+module.exports = turbo({
+  type: 'object',
+  ordered: true,
+  properties: {
+    pid: {type: 'number'},
+    tid: {type: 'number'},
+    ts: {type: 'number'},
+    tts: {type: 'number'},
+    ph: {type: 'string'},
+    cat: {type: 'string'},
+    name: {type: 'string'},
+    dur: {type: 'number'},
+    tdur: {type: 'number'},
+    id: {type: 'string'},
+    args: {
+      type: 'object',
+      properties: {
+        node: {type: 'string'},
+        name: {type: 'string'},
+        executionAsyncId: {type: 'number'},
+        triggerAsyncId: {type: 'number'}
+      }
+    }
+  }
+}, {
+  // we trust the input so no need for fullMatch and validate
+  // also none of the strings have escaped props, so we can
+  // disable string escaping as well for a nice boost
+  fullMatch: false,
+  validate: false,
+  unescapeStrings: false,
+  defaults: false
+})

--- a/test.js
+++ b/test.js
@@ -1,10 +1,25 @@
 const tape = require('tape')
 const parser = require('./')
 
+function sample () {
+  return {
+    pid: 42,
+    tid: Date.now(),
+    name: Math.random().toString(),
+    args: {
+      executionAsyncId: Date.now()
+    }
+  }
+}
+
+function stringify (samples) {
+  return JSON.stringify({traceEvents: samples})
+}
+
 tape('basic nested', function (t) {
   const parse = parser()
-  const expected = [{ a: true, b: {} }, { a: false, b: { c: {} } }]
-  const testData = '{"traceEvents":[{"a":true,"b":{}},{"a":false,"b":{"c":{}}}]}'
+  const expected = [sample(), sample()]
+  const testData = stringify(expected)
   parse.write(testData)
   parse.end()
 
@@ -20,8 +35,9 @@ tape('basic nested', function (t) {
 
 tape('chunked nested', function (t) {
   const parse = parser()
-  const expected = [{ a: true, b: {} }, { a: false, b: { c: {} } }]
-  const testData = '{"traceEvents":[{"a":true,"b":{}},{"a":false,"b":{"c":{}}}]}'
+  const expected = [sample(), sample()]
+  const testData = stringify(expected)
+
   for (var i = 0; i < testData.length; i++) {
     parse.write(testData.slice(i, i + 1))
   }
@@ -39,9 +55,9 @@ tape('chunked nested', function (t) {
 
 tape('basic', function (t) {
   const parse = parser()
-  const expected = [{ a: true, b: {} }, { a: false, b: {} }]
+  const expected = [sample(), sample()]
 
-  parse.write('{"traceEvents":[{"a":true,"b":{}},{"a":false,"b":{}}]}')
+  parse.write(stringify(expected))
   parse.end()
 
   parse
@@ -56,8 +72,8 @@ tape('basic', function (t) {
 
 tape('chunked', function (t) {
   const parse = parser()
-  const expected = [{ a: true, b: {} }, { a: false, b: {} }]
-  const s = '{"traceEvents":[{"a":true,"b":{}},{"a":false,"b":{}}]}'
+  const expected = [sample(), sample()]
+  const s = stringify(expected)
 
   for (var i = 0; i < s.length; i++) {
     parse.write(s.slice(i, i + 1))


### PR DESCRIPTION
Speeds up the trace event parser by 3-4x, making us >10x faster than a simple JSONStream.parse