### PR TITLE
emit 'error' event for invalid json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/index.js
+++ b/index.js
@@ -37,11 +37,16 @@ class Parser extends Transform {
           parse.pointer++
           this.push(msg)
         } catch (err) {
-          const rem = '[' + str.slice(parse.pointer, last + 2) + ']'
-          for (const msg of JSON.parse(rem)) {
-            this.push(msg)
+          try {
+            const rem = '[' + str.slice(parse.pointer, last + 2) + ']'
+            for (const msg of JSON.parse(rem)) {
+              this.push(msg)
+            }
+            parse.pointer = last + 3
+          } catch (err) {
+            cb(err)
+            return
           }
-          parse.pointer = last + 3
         }
       }
       this._buffer = str.slice(parse.pointer)

--- a/test.js
+++ b/test.js
@@ -89,3 +89,26 @@ tape('chunked', function (t) {
       t.end()
     })
 })
+
+tape('invalid json', function (t) {
+  t.plan(2)
+  const parse = parser()
+  const expected = [sample()]
+  const s = '{"traceEvents":[' + JSON.stringify(expected[0]) + ', {"x":"x"]}},]}'
+
+  for (var i = 0; i < s.length; i++) {
+    parse.write(s.slice(i, i + 1))
+  }
+  parse.end()
+
+  parse
+    .on('data', function (data) {
+      t.same(data, expected.shift())
+    })
+    .on('error', function (error) {
+      t.ok(error)
+    })
+    .on('end', function () {
+      t.fail()
+    })
+})


### PR DESCRIPTION
instead of crashing the process immediately.

this will allow clinic doctor to print a helpful error message when the 
trace event output is unexpected. usually that means that multiple node.js
processes are writing interleaved trace event data.